### PR TITLE
Reduce deprecation warnings

### DIFF
--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -423,7 +423,7 @@ extension GenericJSONParser {
     
     private func advance() {
         assert(cur != end, "out of range")
-        cur++
+        cur += 1
         
         if cur != end {
             switch currentChar {

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -423,7 +423,7 @@ extension GenericJSONParser {
     
     private func advance() {
         assert(cur != end, "out of range")
-        cur += 1
+        cur++
         
         if cur != end {
             switch currentChar {

--- a/Sources/JSONSerializer.swift
+++ b/Sources/JSONSerializer.swift
@@ -53,7 +53,7 @@ public class DefaultJSONSerializer: JSONSerializer {
     func serializeArray(a: [JSON]) -> String {
         var s = "["
 
-        for var i = 0; i < a.count; i++ {
+        for i in 0 ..< a.count {
             s += a[i].serialize(self)
 
             if i != (a.count - 1) {
@@ -70,9 +70,10 @@ public class DefaultJSONSerializer: JSONSerializer {
 
         for entry in o {
             s += "\(escapeAsJSONString(entry.0)):\(entry.1.serialize(self))"
-            if i++ != (o.count - 1) {
+            if i != (o.count - 1) {
                 s += ","
             }
+            i += 1
         }
 
         return s + "}"
@@ -84,9 +85,9 @@ public final class PrettyJSONSerializer: DefaultJSONSerializer {
 
     override public func serializeArray(a: [JSON]) -> String {
         var s = "["
-        indentLevel++
+        indentLevel += 1
 
-        for var i = 0; i < a.count; i++ {
+        for i in 0 ..< a.count {
             s += "\n"
             s += indent()
             s += a[i].serialize(self)
@@ -96,13 +97,13 @@ public final class PrettyJSONSerializer: DefaultJSONSerializer {
             }
         }
 
-        indentLevel--
+        indentLevel -= 1
         return s + "\n" + indent() + "]"
     }
 
     override public func serializeObject(o: [String: JSON]) -> String {
         var s = "{"
-        indentLevel++
+        indentLevel += 1
         var i = 0
 
         var keys = Array(o.keys)
@@ -113,19 +114,20 @@ public final class PrettyJSONSerializer: DefaultJSONSerializer {
             s += indent()
             s += "\(escapeAsJSONString(key)): \(o[key]!.serialize(self))"
 
-            if i++ != (o.count - 1) {
+            if i != (o.count - 1) {
                 s += ","
             }
+            i += 1
         }
 
-        indentLevel--
+        indentLevel -= 1
         return s + "\n" + indent() + "}"
     }
 
     func indent() -> String {
         var s = ""
 
-        for var i = 0; i < indentLevel; i++ {
+        for _ in 0 ..< indentLevel {
             s += "    "
         }
 


### PR DESCRIPTION
I know you guys have moved on to using JSON out of Core but I'm continuing to use your standalone code and I thought it'd be useful to reduce the number of deprecation warnings with latest version of Swift.
