### PR TITLE
Fixes issue with some types being silently ignored when serializing a [String:Any] or [Any]

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// This file has been modified from its original project Swift-JSONSerializer
+// This file has been modified from its original project Swift-JsonSerializer
 
 public enum JSON {
     case NullValue

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// This file has been modified from its original project Swift-JsonSerializer
+// This file has been modified from its original project Swift-JSONSerializer
 
 public enum JSON {
     case NullValue
@@ -36,6 +36,10 @@ public enum JSON {
         return .BooleanValue(value)
     }
 
+    public static func from(value: Int) -> JSON {
+        return .NumberValue(Double(value))
+    }
+    
     public static func from(value: Double) -> JSON {
         return .NumberValue(value)
     }
@@ -47,56 +51,56 @@ public enum JSON {
     public static func from(value: [JSON]) -> JSON {
         return .ArrayValue(value)
     }
+    
+    private static func fromArr<T>(value:[T]) -> JSON {
+        return JSON.from(value.map { JSON.from($0) } )
+    }
+    
+    public static func from(value: [Int]) -> JSON {
+        return fromArr(value)
+    }
+    
+    public static func from(value: [String]) -> JSON {
+        return fromArr(value)
+    }
+    
+    public static func from(value: [Double]) -> JSON {
+        return fromArr(value)
+    }
+    
+    public static func from(value: [Any]) -> JSON {
+        return fromArr(value)
+    }
+    
+    public static func from(value: Any) -> JSON {
+        if let value = value as? Int {
+            return JSON.from(value)
+        } else if let value = value as? Double {
+            return JSON.from(value)
+        } else if let value = value as? String {
+            return JSON.from(value)
+        } else if let value = value as? [Int] {
+            return JSON.from(value)
+        } else if let value = value as? [Double] {
+            return JSON.from(value)
+        } else if let value = value as? [Any] {
+            return JSON.from(value)
+        } else if let value = value as? [String] {
+            return JSON.from(value)
+        } else if let value = value as? [String:Any] {
+            var dict : [String: JSON] = [:]
+            for (k,v) in value {
+                dict[k] = JSON.from(v)
+            }
+            return JSON.from(dict)
+        }
+        /* We have to give up, don't have a rule for this type. Should probably throw an error */
+		//print("Giving up: \(value), \(value.dynamicType)")
+        return .StringValue("\(value)")
+    }
 
-    public static func from(value: [String: JSON]) -> JSON {
+    public static func from(value: [String : JSON]) -> JSON {
         return .ObjectValue(value)
-    }
-
-    // TODO: decide what to do if Any is not a JSON value
-    public static func from(values: [Any]) -> JSON {
-        var jsonArray: [JSON] = []
-        for value in values {
-            if let value = value as? Bool {
-                jsonArray.append(JSON.from(value))
-            }
-            if let value = value as? Double {
-                jsonArray.append(JSON.from(value))
-            }
-            if let value = value as? String {
-                jsonArray.append(JSON.from(value))
-            }
-            if let value = value as? [Any] {
-                jsonArray.append(JSON.from(value))
-            }
-            if let value = value as? [String: Any] {
-                jsonArray.append(JSON.from(value))
-            }
-        }
-        return JSON.from(jsonArray)
-    }
-
-    // TODO: decide what to do if Any is not a JSON value
-    public static func from(value: [String: Any]) -> JSON {
-        var jsonDictionary: [String: JSON] = [:]
-        for (key, value) in value {
-            if let value = value as? Bool {
-                jsonDictionary[key] = JSON.from(value)
-            }
-            if let value = value as? Double {
-                jsonDictionary[key] = JSON.from(value)
-            }
-            if let value = value as? String {
-                jsonDictionary[key] = JSON.from(value)
-            }
-            if let value = value as? [Any] {
-                jsonDictionary[key] = JSON.from(value)
-            }
-            if let value = value as? [String: Any] {
-                jsonDictionary[key] = JSON.from(value)
-            }
-        }
-
-        return JSON.from(jsonDictionary)
     }
 
     public var isBoolean: Bool {


### PR DESCRIPTION
See issue https://github.com/Zewo/JSON/issues/3

Test with: 

let dict : [String : Any] = [
    "string" : "abcde",
    "int" : 123,
    "double" : 1.0,
    "array str" : ["s1", "s2", "s3"],
    "array double" : [1.2, 2.3, 3.4],
    "array int" : [0, 1, 2, -1]
]
let json = Json.from(dict)
print("DICT: (dict)\nJSON: (json)")
